### PR TITLE
Add retry limit to transmissions

### DIFF
--- a/ft8ctrl.yaml.sample
+++ b/ft8ctrl.yaml.sample
@@ -13,6 +13,8 @@ ft8ctrl:
   follow_frequency: False
   retry_time: 15                 # In minutes
   tx_power: 30
+  # tx_retries determines how many times to attempt the same message before stopping transmission
+  tx_retries: 5
   # Specify which call_selector you want to use, then check the plugin configuration
   # The selector 'Any' accept any callsigns.
   call_selector:

--- a/wsjtx.py
+++ b/wsjtx.py
@@ -363,20 +363,20 @@ class WSStatus(_WSPacket):
     return self._data['SOMode']
 
   @property
-  def reqTolerance(self):
-    return self._data['reqTolerance']
+  def FreqTolerance(self):
+    return self._data['FreqTolerance']
 
   @property
-  def RPeriod(self):
-    return self._data['RPeriod']
+  def TRPeriod(self):
+    return self._data['TRPeriod']
 
   @property
-  def onfigName(self):
-    return self._data['onfigName']
+  def ConfigName(self):
+    return self._data['ConfigName']
 
   @property
-  def xMessage(self):
-    return self._data['xMessage']
+  def TxMessage(self):
+    return self._data['TxMessage']
 
 
 class WSDecode(_WSPacket):


### PR DESCRIPTION
Currently, if within WSJT-X, a transmission can go on forever, specially if the other station cannot "hear" you. This PR adds a re-try counter that's configurable. If your transmission is sent X amount of times and not responded to, FT8Commander will automatically stop the transmission and move on to the next plausible QSO.